### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To-do:
 |------|-------------|------|---------|:--------:|
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window. | `bool` | `false` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | This parameter does not apply to Amazon DocumentDB.Amazon DocumentDB does not perform minor version upgrades regardless of the value set. | `bool` | `false` | no |
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of EC2 Availability Zones that instances in the DB cluster can be created in. | `list(string)` | n/a | yes |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of EC2 Availability Zones that instances in the DB cluster can be created in. | `list(string)` | n/a | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | The days to retain backups for. | `number` | `7` | no |
 | <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | The cluster identifier. If omitted, Terraform will assign a random, unique identifier. | `string` | n/a | yes |
 | <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Number of instances. | `number` | `3` | no |

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ To-do:
 | <a name="input_subnet_description"></a> [subnet\_description](#input\_subnet\_description) | Allowed subnets for DB cluster instances. | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of VPC subnet IDs. | `list(string)` | `[]` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of VPC security groups to associate with the Cluster. | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [vpc\_tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "docdb_subnet_group" {
   subnet_ids  = var.subnet_ids
   description = var.subnet_description
   name_prefix = var.sg_name_prefix
+  tags        = var.tags
 }
 
 module "docdb_parameter_group" {
@@ -35,6 +36,7 @@ module "docdb_parameter_group" {
   family      = var.family
   description = "${var.parameter_description} ${var.cluster_identifier}"
   parameters  = var.parameters
+  tags        = var.tags
 }
 
 resource "aws_docdb_cluster" "this" {
@@ -60,9 +62,12 @@ resource "aws_docdb_cluster" "this" {
   skip_final_snapshot             = var.skip_final_snapshot
   deletion_protection             = var.deletion_protection
   apply_immediately               = var.apply_immediately
-  tags = {
-    "Engine" = var.engine
-  }
+  tags = merge(
+    var.tags,
+    {
+      "Engine" = var.engine
+    }
+  )
 }
 
 resource "aws_docdb_cluster_instance" "this" {
@@ -78,7 +83,10 @@ resource "aws_docdb_cluster_instance" "this" {
   preferred_maintenance_window    = var.preferred_maintenance_window
   promotion_tier                  = var.promotion_tier
   apply_immediately               = var.apply_immediately
-  tags = {
-    "Engine" = var.engine
-  }
+  tags = merge(
+    var.tags,
+    {
+      "Engine" = var.engine
+    }
+  )
 }

--- a/modules/docdb_parameter_group/main.tf
+++ b/modules/docdb_parameter_group/main.tf
@@ -3,6 +3,7 @@ resource "aws_docdb_cluster_parameter_group" "this" {
   family      = var.family
   name        = var.name
   description = var.description
+  tags        = var.tags
 
   dynamic "parameter" {
     for_each = var.parameters

--- a/modules/docdb_parameter_group/variables.tf
+++ b/modules/docdb_parameter_group/variables.tf
@@ -20,3 +20,9 @@ variable "create" {
   type    = bool
   default = false
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to add to all resources"
+}

--- a/modules/docdb_subnet_group/main.tf
+++ b/modules/docdb_subnet_group/main.tf
@@ -4,4 +4,5 @@ resource "aws_docdb_subnet_group" "this" {
   name        = var.name
   subnet_ids  = var.subnet_ids
   description = var.description
+  tags        = var.tags
 }

--- a/modules/docdb_subnet_group/variables.tf
+++ b/modules/docdb_subnet_group/variables.tf
@@ -19,3 +19,9 @@ variable "name_prefix" {
   type    = string
   default = null
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to add to all resources"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,7 @@ variable "apply_immediately" {
 
 variable "availability_zones" {
   type        = list(string)
+  default     = null
   description = "A list of EC2 Availability Zones that instances in the DB cluster can be created in."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -240,3 +240,9 @@ variable "parameters" {
   default     = []
   description = "List of DB parameters to apply."
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to add to all resources"
+}


### PR DESCRIPTION
* Add tags - fix #3
* Make `availability_zones` variable optional: currently Terraform AWS provider in aws_docdb_cluster resource forces this parameter to be an array of all AZ available in region.